### PR TITLE
[Bugfix] Enabled two or more feeds

### DIFF
--- a/app/code/community/Ikonoshirt/CustomAdminNotifications/Model/Feed.php
+++ b/app/code/community/Ikonoshirt/CustomAdminNotifications/Model/Feed.php
@@ -61,7 +61,7 @@ class Ikonoshirt_CustomAdminNotifications_Model_Feed
                         'date_added'  => $this->getDate((string)$item->pubDate),
                         'title'       => (string)$item->title,
                         'description' => (string)$item->description,
-                        'url'         => (string)$item->link,
+                        'url'         => ( $item->link ? (string)$item->link : null ),
                     );
                 }
 


### PR DESCRIPTION
When two or more feeds are configured, only the first one was checked for updates as the cache entry for the last check time is not feed dependant but global.
